### PR TITLE
Changed version format in package.json and updated packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "Utility module to check istanbul thresholds",
   "main": "index.js",
   "dependencies": {
-    "istanbul": "0.3.*",
-    "lodash": "3.6.*"
+    "istanbul": "^0.3.17",
+    "lodash": "^3.10.0"
   },
   "devDependencies": {
-    "assert": "1.3.*",
-    "gulp": "3.8.*",
-    "gulp-istanbul": "0.8.*",
-    "gulp-jscs": "1.4.*",
-    "gulp-mocha": "2.0.*",
-    "istanbul-text-full-reporter": "0.1.*",
-    "sinon": "1.14.*"
+    "assert": "^1.3.0",
+    "gulp": "^3.9.0",
+    "gulp-istanbul": "^0.10.0",
+    "gulp-jscs": "^1.6.0",
+    "gulp-mocha": "^2.1.2",
+    "istanbul-text-full-reporter": "^0.1.2",
+    "sinon": "^1.15.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I don't know if there's a specific reason for the `x.x.*` format (equivalent to the `~x.x.x`).
I hope it helps. This suppresses some npm warnings.
BTW tests passed.
