### PR TITLE
Require istanbul utils with deep path to prevent loading entire module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var utils = require('istanbul').utils;
+var utils = require('istanbul/lib/object-utils');
 
 var TYPES = ['lines', 'statements', 'functions', 'branches'];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-threshold-checker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Utility module to check istanbul thresholds",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Loading a copy of instanbul `utils with`require('istanbul').utils` loads the entire module which includes handlebars helpers that override globals.

This causes version conflicts with coverage rendering. Example:

https://github.com/cb1kenobi/gulp-babel-istanbul/commit/f06082597d788bfcc0a962a3c524b7b08e0abd91

A simple work-around is to grab just the file that is being used.

https://github.com/gotwarlost/istanbul/blob/8883845837d44cb238d60cc072cd4a3dcc454849/index.js#L87

Thanks!
